### PR TITLE
fix project config

### DIFF
--- a/MahjongAI/MahjongAI.csproj
+++ b/MahjongAI/MahjongAI.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/MahjongAI/MahjongAI.csproj
+++ b/MahjongAI/MahjongAI.csproj
@@ -32,7 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
After this commit https://github.com/zhangjk95/MahjongAI/commit/e9868f08f7f74001d4cdbd21b03eebefde7d484f  build process is broken. 
```
Done Building Project "/usr/src/app/MahjongAI/MahjongAI.csproj" (default targets) -- FAILED.
Done Building Project "/usr/src/app/MahjongAI.sln" (Build target(s)) -- FAILED.

Build FAILED.

"/usr/src/app/MahjongAI.sln" (Build target) (1) ->
"/usr/src/app/MahjongAI/MahjongAI.csproj" (default target) (2) ->
(ResolveAssemblyReferences target) ->
  /usr/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(2218,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "Newto
nsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL". Check to make sure the assembly exists on disk. If this referen
ce is required by your code, you may get compilation errors. [/usr/src/app/MahjongAI/MahjongAI.csproj]
```

This commit fix project config for build.